### PR TITLE
API backend address fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "minr",
   "productName": "minr",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A GUI for PacketCrypt by PKT Watch",
   "homepage": "https://pkt.watch/minr",
   "repository": {

--- a/src/wallet-mgr.js
+++ b/src/wallet-mgr.js
@@ -1,6 +1,6 @@
 const utils = require('./utils');
 
-const apiBase = 'https://explorer.pkt.cash/api/v1/PKT/pkt/';
+const apiBase = 'https://explorer-api.pkt.ai/api/v1/PKT/pkt/';
 
 exports.getAddress = (addr) => {
     if (!addr) addr = DEFAULT_PAYMENT_ADDRESS;


### PR DESCRIPTION
The old `https://explorer.pkt.cash/api/v1/PKT/pkt/` is not available for a good amount of months. This PR is making use of `https://explorer-api.pkt.ai/api/v1/PKT/pkt/` which runs normally.